### PR TITLE
Add additional configuration to control the return pathname

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,18 @@ To use the `signOut` method, you'll need to set your app's homepage in your Work
 WorkOS requires that you have a callback URL to redirect users back to after they've authenticated. In your Next.js app, [expose an API route](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) and add the following.
 
 ```ts
-export { authkitCallbackRoute as GET } from '@workos-inc/nextjs';
+import { handleAuth } from '@workos-inc/nextjs';
+
+export const GET = handleAuth();
 ```
 
 Make sure this route matches the `WORKOS_REDIRECT_URI` variable and the configured redirect URI in your WorkOS dashboard. For instance if your redirect URI is `http://localhost:3000/auth/callback` then you'd put the above code in `/app/auth/callback/route.ts`.
+
+You can also control the pathname the user will be sent to after signing-in by passing a `returnPathname` option to `handleAuth` like so:
+
+```ts
+export const GET = handleAuth({ returnPathname: '/dashboard' });
+```
 
 ### Middleware
 

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -4,10 +4,7 @@ import { workos } from './workos.js';
 import { WORKOS_CLIENT_ID } from './env-variables.js';
 import { encryptSession } from './session.js';
 import { cookieName, cookieOptions } from './cookie.js';
-
-interface HandleAuthOptions {
-  returnPathname?: string;
-}
+import { HandleAuthOptions } from './interfaces.js';
 
 export function handleAuth(options: HandleAuthOptions = {}) {
   const { returnPathname: returnPathnameOption = '/' } = options;
@@ -32,7 +29,7 @@ export function handleAuth(options: HandleAuthOptions = {}) {
         url.searchParams.delete('state');
 
         // Redirect to the requested path and store the session
-        url.pathname = returnPathname ? returnPathname : returnPathnameOption;
+        url.pathname = returnPathname ?? returnPathnameOption;
 
         const response = NextResponse.redirect(url);
 

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -5,56 +5,68 @@ import { WORKOS_CLIENT_ID } from './env-variables.js';
 import { encryptSession } from './session.js';
 import { cookieName, cookieOptions } from './cookie.js';
 
-export async function authkitCallbackRoute(request: NextRequest) {
-  const code = request.nextUrl.searchParams.get('code');
-
-  if (code) {
-    try {
-      // Use the code returned to us by AuthKit and authenticate the user with WorkOS
-      const { accessToken, refreshToken, user, impersonator } = await workos.userManagement.authenticateWithCode({
-        clientId: WORKOS_CLIENT_ID,
-        code,
-      });
-
-      const url = request.nextUrl.clone();
-
-      // Cleanup params
-      url.searchParams.delete('code');
-
-      // Redirect to the requested path and store the session
-      url.pathname = '/';
-      const response = NextResponse.redirect(url);
-
-      if (!accessToken || !refreshToken) throw new Error('response is missing tokens');
-
-      // The refreshToken should never be accesible publicly, hence why we encrypt it in the cookie session
-      // Alternatively you could persist the refresh token in a backend database
-      const session = await encryptSession({ accessToken, refreshToken, user, impersonator });
-      cookies().set(cookieName, session, cookieOptions);
-
-      return response;
-    } catch (error) {
-      const errorRes = {
-        error: error instanceof Error ? error.message : String(error),
-      };
-
-      console.error(errorRes);
-
-      return errorResponse();
-    }
-  }
-
-  return errorResponse();
+interface HandleAuthOptions {
+  returnPathname?: string;
 }
 
-function errorResponse() {
-  return NextResponse.json(
-    {
-      error: {
-        message: 'Something went wrong',
-        description: 'Couldn’t sign in. If you are not sure what happened, please contact your organization admin.',
+export function handleAuth(options: HandleAuthOptions = {}) {
+  const { returnPathname: returnPathnameOption = '/' } = options;
+
+  return async function GET(request: NextRequest) {
+    const code = request.nextUrl.searchParams.get('code');
+    const state = request.nextUrl.searchParams.get('state');
+    const returnPathname = state ? JSON.parse(atob(state)).returnPathname : null;
+
+    if (code) {
+      try {
+        // Use the code returned to us by AuthKit and authenticate the user with WorkOS
+        const { accessToken, refreshToken, user, impersonator } = await workos.userManagement.authenticateWithCode({
+          clientId: WORKOS_CLIENT_ID,
+          code,
+        });
+
+        const url = request.nextUrl.clone();
+
+        // Cleanup params
+        url.searchParams.delete('code');
+        url.searchParams.delete('state');
+
+        // Redirect to the requested path and store the session
+        url.pathname = returnPathname ? returnPathname : returnPathnameOption;
+
+        const response = NextResponse.redirect(url);
+
+        if (!accessToken || !refreshToken) throw new Error('response is missing tokens');
+
+        // The refreshToken should never be accesible publicly, hence why we encrypt it in the cookie session
+        // Alternatively you could persist the refresh token in a backend database
+        const session = await encryptSession({ accessToken, refreshToken, user, impersonator });
+        cookies().set(cookieName, session, cookieOptions);
+
+        return response;
+      } catch (error) {
+        const errorRes = {
+          error: error instanceof Error ? error.message : String(error),
+        };
+
+        console.error(errorRes);
+
+        return errorResponse();
+      }
+    }
+
+    return errorResponse();
+  };
+
+  function errorResponse() {
+    return NextResponse.json(
+      {
+        error: {
+          message: 'Something went wrong',
+          description: 'Couldn’t sign in. If you are not sure what happened, please contact your organization admin.',
+        },
       },
-    },
-    { status: 500 },
-  );
+      { status: 500 },
+    );
+  }
 }

--- a/src/get-authorization-url.ts
+++ b/src/get-authorization-url.ts
@@ -1,11 +1,12 @@
 import { workos } from './workos.js';
 import { WORKOS_CLIENT_ID, WORKOS_REDIRECT_URI } from './env-variables.js';
 
-async function getAuthorizationUrl() {
+async function getAuthorizationUrl(returnPathname?: string) {
   return workos.userManagement.getAuthorizationUrl({
     provider: 'authkit',
     clientId: WORKOS_CLIENT_ID,
     redirectUri: WORKOS_REDIRECT_URI,
+    state: returnPathname ? btoa(JSON.stringify({ returnPathname })) : undefined,
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
-import { authkitCallbackRoute } from './authkit-callback-route.js';
+import { handleAuth } from './authkit-callback-route.js';
 import { authkitMiddleware } from './middleware.js';
 import { getUser } from './session.js';
 import { getSignInUrl, signOut } from './auth.js';
 import { Impersonation } from './impersonation.js';
 
 export {
-  authkitCallbackRoute,
+  handleAuth,
   //
   authkitMiddleware,
   //

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,9 @@
 import { User } from '@workos-inc/node';
 
+export interface HandleAuthOptions {
+  returnPathname?: string;
+}
+
 export interface Impersonator {
   email: string;
   reason: string | null;

--- a/src/session.ts
+++ b/src/session.ts
@@ -83,7 +83,8 @@ async function getUser({ ensureSignedIn = false } = {}) {
   const session = await getSessionFromHeader();
   if (!session) {
     if (ensureSignedIn) {
-      redirect(await getAuthorizationUrl());
+      const returnPathname = headers().get('next-url') ?? undefined;
+      redirect(await getAuthorizationUrl(returnPathname));
     }
     return { user: null };
   }


### PR DESCRIPTION
This PR handles a couple things:

- Changes the way the callback route is configured, to enable passing some options (notably an option to configure the default return pathname)
- Handles returning the user to the pathname they attempted before they were thrown to sign-in when `ensureSignedIn` is `true` in `getUser()`

Fixes #11 